### PR TITLE
Update to  CardboardEditor.cs.

### DIFF
--- a/Cardboard/Editor/CardboardEditor.cs
+++ b/Cardboard/Editor/CardboardEditor.cs
@@ -119,10 +119,10 @@ public class CardboardEditor : Editor {
     if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.iPhone
         && !Application.isPlaying
         && Object.FindObjectOfType<Cardboard>() != null
-        && PlayerSettings.targetIOSGraphics != TargetIOSGraphics.OpenGLES_2_0
-        && PlayerSettings.targetIOSGraphics != TargetIOSGraphics.OpenGLES_3_0) {
-      Debug.LogWarning("iOS Graphics API should be set to OpenGL for best distortion-"
-        + "correction performance in Cardboard.");
+        && PlayerSettings.GetGraphicsAPIs(BuildTarget.iPhone).Contains(GraphicsDeviceType.OpenGLES2)
+        && PlayerSettings.GetGraphicsAPIs(BuildTarget.iPhone).Contains(GraphicsDeviceType.OpenGLES3)){
+        Debug.LogWarning("iOS Graphics API should be set to OpenGL for best distortion-"
+          + "correction performance in Cardboard.");
     }
   }
 }


### PR DESCRIPTION
Here is patch for "error CS0117: `UnityEditor.PlayerSettings' does not contain a definition for 'target IOS Graphics'" in CardboardEditor.cs.`UnityEditor.PlayerSettings' does not contain a definition for 'target IOS Graphics'" in CardboardEditor.cs.

Here are list of SDK's and software's I am using :
1.0 Unity 4.6.2 ( Target Platform : Android )
 2.0 Cardboard SDK for Unity v0.5
